### PR TITLE
Update function names; v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,23 @@ bigint from hex string from buffer (huge): 1230607±1.02% ops/s 812.61±40.013 n
 
 bigint-buffer introduces four functions for conversion between buffers and bigints. A small example follows:
 ```typescript
-import {BEToBigInt, LEToBigInt, ToBEBuffer, ToLEBuffer} from 'bigint-buffer';
+import {toBigIntBE, toBigIntLE, toBufferBE, toBufferLE} from 'bigint-buffer';
 
 // Get a big endian buffer of the given width
-ToBEBuffer(0xdeadbeefn, 8);
-// > <Buffer 00 00 00 00 de ad be ef>
+toBufferBE(0xdeadbeefn, 8);
+// ↪ <Buffer 00 00 00 00 de ad be ef>
 
 // Get a little endian buffer of the given width
-ToLEBuffer(0xdeadbeefn, 8);
-// > <Buffer ef be ad de 00 00 00 00>
+toBufferLE(0xdeadbeefn, 8);
+// ↪ <Buffer ef be ad de 00 00 00 00>
 
 // Get a BigInt from a buffer in big endian format
-BEToBigInt(Buffer.from('deadbeef', 'hex'));
-// > 3735928559n (0xdeadbeefn)
+toBigIntBE(Buffer.from('deadbeef', 'hex'));
+// ↪ 3735928559n (0xdeadbeefn)
 
 // Get a BigInt from a buffer in little endian format
-LEToBigInt(Buffer.from('deadbeef', 'hex'));
+toBigIntLE(Buffer.from('deadbeef', 'hex'));
+// ↪ 4022250974n (0xefbeadd0en)
 ```
 
 bigint-buffer uses N-API native bindings to perform the conversion efficiently without generating the
@@ -96,7 +97,8 @@ Add bigint-buffer to your project with:
 
 # Documentation
 
-Basic API documentation can be found [here](https://no2chem.github.io/bigint-buffer/).
+Basic API documentation can be found [here](https://no2chem.github.io/bigint-buffer/). Note that v1.0.0 changes
+the name of the original functions to meet style guidelines.
 
 # Benchmarks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,7 +1,7 @@
 
 import * as benchmark from 'benchmark';
 
-import {BEToBigInt, LEToBigInt, ToBEBuffer, ToLEBuffer} from './index';
+import {toBigIntBE, toBigIntLE, toBufferBE, toBufferLE} from './index';
 
 
 // This file contains the benchmark test suite. It includes the benchmark and
@@ -29,10 +29,10 @@ suite.add('bigint from hex string from buffer (small)', () => {
   BigInt(`0x${smallBuf.toString('hex')}`);
 });
 suite.add('LE bigint-buffer ToBigInt (small)', () => {
-  LEToBigInt(smallBuf);
+  toBigIntLE(smallBuf);
 });
 suite.add('BE bigint-buffer ToBigInt (small)', () => {
-  BEToBigInt(smallBuf);
+  toBigIntBE(smallBuf);
 });
 
 // Test mid strings (aligned)
@@ -46,10 +46,10 @@ suite.add('bigint from hex string from buffer (mid, aligned)', () => {
   BigInt(`0x${midBuf.toString('hex')}`);
 });
 suite.add('LE bigint-buffer ToBigInt (mid, aligned)', () => {
-  LEToBigInt(midBuf);
+  toBigIntLE(midBuf);
 });
 suite.add('BE bigint-buffer ToBigInt (mid, aligned)', () => {
-  BEToBigInt(midBuf);
+  toBigIntBE(midBuf);
 });
 
 // Test huge strings
@@ -64,10 +64,10 @@ suite.add('bigint from hex string from buffer (huge)', () => {
   BigInt(`0x${hugeBuf.toString('hex')}`);
 });
 suite.add('LE bigint-buffer ToBigInt (huge)', () => {
-  LEToBigInt(hugeBuf);
+  toBigIntLE(hugeBuf);
 });
 suite.add('BE bigint-buffer ToBigInt (huge)', () => {
-  BEToBigInt(hugeBuf);
+  toBigIntBE(hugeBuf);
 });
 
 const bigIntToBufferWithStringBE = (int: bigint, width: number): Buffer => {
@@ -94,11 +94,11 @@ suite.add('BE bigint to hex string to buffer (small)', () => {
 });
 
 suite.add('LE bigint-buffer to buffer (small)', () => {
-  ToLEBuffer(smallValue, 8);
+  toBufferLE(smallValue, 8);
 });
 
 suite.add('BE bigint-buffer to buffer (small)', () => {
-  ToBEBuffer(smallValue, 8);
+  toBufferBE(smallValue, 8);
 });
 
 // Test large toBuffer
@@ -113,11 +113,11 @@ suite.add('BE bigint to hex string to buffer (large)', () => {
 });
 
 suite.add('LE bigint-buffer to buffer (large)', () => {
-  ToLEBuffer(largeValue, 24);
+  toBufferLE(largeValue, 24);
 });
 
 suite.add('BE bigint-buffer to buffer (large)', () => {
-  ToBEBuffer(largeValue, 24);
+  toBufferBE(largeValue, 24);
 });
 
 suite.add('LE bigint to hex string to buffer (large)', () => {
@@ -129,11 +129,11 @@ suite.add('BE bigint to hex string to buffer (large)', () => {
 });
 
 suite.add('LE bigint-buffer to buffer (large, truncated)', () => {
-  ToLEBuffer(largeValue, 8);
+  toBufferLE(largeValue, 8);
 });
 
 suite.add('BE bigint-buffer to buffer (large, truncated)', () => {
-  ToBEBuffer(largeValue, 8);
+  toBufferBE(largeValue, 8);
 });
 
 const b1 = Buffer.from('0123456789ABCDEF0123456789ABCDEF', 'hex');

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,10 +6,10 @@ import * as path from 'path';
 
 const lib = process.browser ? require('../../dist/browser') :
                               require(path.join(__dirname, '../dist/node'));
-const BEToBigInt = lib.BEToBigInt;
-const LEToBigInt = lib.LEToBigInt;
-const ToBEBuffer = lib.ToBEBuffer;
-const ToLEBuffer = lib.ToLEBuffer;
+const toBigIntBE = lib.toBigIntBE;
+const toBigIntLE = lib.toBigIntLE;
+const toBufferBE = lib.toBufferBE;
+const toBufferLE = lib.toBufferLE;
 
 // Needed for should.not.be.undefined.
 /* tslint:disable:no-unused-expression */
@@ -23,44 +23,44 @@ const assertEquals = (n0: BigInt, n1: BigInt) => {
 
 describe('Try buffer conversion (little endian)', () => {
   it('0 should equal 0n', () => {
-    assertEquals(LEToBigInt(Buffer.from([0])), BigInt('0'));
+    assertEquals(toBigIntLE(Buffer.from([0])), BigInt('0'));
   });
 
   it('1 should equal 1n', async () => {
-    assertEquals(LEToBigInt(Buffer.from([1])), BigInt('1'));
+    assertEquals(toBigIntLE(Buffer.from([1])), BigInt('1'));
   });
 
   it('0xdead should equal 0xdeadn', async () => {
-    assertEquals(LEToBigInt(Buffer.from([0xad, 0xde])), BigInt(`0xdead`));
+    assertEquals(toBigIntLE(Buffer.from([0xad, 0xde])), BigInt(`0xdead`));
   });
 
   it('0xdeadbeef should equal 0xdeadbeefn', async () => {
     assertEquals(
-        LEToBigInt(Buffer.from([0xef, 0xbe, 0xad, 0xde])),
+        toBigIntLE(Buffer.from([0xef, 0xbe, 0xad, 0xde])),
         BigInt(`0xdeadbeef`));
   });
 
   it('0xbadc0ffee0 should equal 0xbadc0ffee0n', async () => {
     assertEquals(
-        LEToBigInt(Buffer.from([0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
+        toBigIntLE(Buffer.from([0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
         BigInt(`0xbadc0ffee0`));
   });
 
   it('0xbadc0ffee0dd should equal 0xbadc0ffee0ddn', async () => {
     assertEquals(
-        LEToBigInt(Buffer.from([0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
+        toBigIntLE(Buffer.from([0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
         BigInt(`0xbadc0ffee0dd`));
   });
 
   it('0xbadc0ffee0ddf0 should equal 0xbadc0ffee0ddf0n', async () => {
     assertEquals(
-        LEToBigInt(Buffer.from([0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
+        toBigIntLE(Buffer.from([0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
         BigInt(`0xbadc0ffee0ddf0`));
   });
 
   it('0xbadc0ffee0ddf00d should equal 0xbadc0ffee0ddf00dn', async () => {
     assertEquals(
-        LEToBigInt(
+        toBigIntLE(
             Buffer.from([0x0d, 0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba])),
         BigInt(`0xbadc0ffee0ddf00d`));
   });
@@ -68,7 +68,7 @@ describe('Try buffer conversion (little endian)', () => {
   it('0xbadc0ffee0ddf00ddeadbeef should equal 0xbadc0ffee0ddf00ddeadbeefn',
      async () => {
        assertEquals(
-           LEToBigInt(Buffer.from([
+           toBigIntLE(Buffer.from([
              0xef, 0xbe, 0xad, 0xde, 0x0d, 0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc,
              0xba
            ])),
@@ -78,44 +78,44 @@ describe('Try buffer conversion (little endian)', () => {
 
 describe('Try buffer conversion (big endian)', () => {
   it('0 should equal 0n', () => {
-    assertEquals(BEToBigInt(Buffer.from([0])), BigInt(`0`));
+    assertEquals(toBigIntBE(Buffer.from([0])), BigInt(`0`));
   });
 
   it('1 should equal 1n', async () => {
-    assertEquals(BEToBigInt(Buffer.from([1])), BigInt(`1`));
+    assertEquals(toBigIntBE(Buffer.from([1])), BigInt(`1`));
   });
 
   it('0xdead should equal 0xdeadn', async () => {
-    assertEquals(BEToBigInt(Buffer.from([0xde, 0xad])), BigInt(`0xdead`));
+    assertEquals(toBigIntBE(Buffer.from([0xde, 0xad])), BigInt(`0xdead`));
   });
 
   it('0xdeadbeef should equal 0xdeadbeefn', async () => {
     assertEquals(
-        BEToBigInt(Buffer.from([0xde, 0xad, 0xbe, 0xef])),
+        toBigIntBE(Buffer.from([0xde, 0xad, 0xbe, 0xef])),
         BigInt(`0xdeadbeef`));
   });
 
   it('0xbadc0ffee0 should equal 0xbadc0ffee0n', async () => {
     assertEquals(
-        BEToBigInt(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0])),
+        toBigIntBE(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0])),
         BigInt(`0xbadc0ffee0`));
   });
 
   it('0xbadc0ffee0dd should equal 0xbadc0ffee0ddn', async () => {
     assertEquals(
-        BEToBigInt(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd])),
+        toBigIntBE(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd])),
         BigInt(`0xbadc0ffee0dd`));
   });
 
   it('0xbadc0ffee0ddf0 should equal 0xbadc0ffee0ddf0n', async () => {
     assertEquals(
-        BEToBigInt(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0])),
+        toBigIntBE(Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0])),
         BigInt(`0xbadc0ffee0ddf0`));
   });
 
   it('0xbadc0ffee0ddf00d should equal 0xbadc0ffee0ddf00dn', async () => {
     assertEquals(
-        BEToBigInt(
+        toBigIntBE(
             Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0, 0x0d])),
         BigInt(`0xbadc0ffee0ddf00d`));
   });
@@ -123,7 +123,7 @@ describe('Try buffer conversion (big endian)', () => {
   it('0xbadc0ffee0ddf00ddeadbeef should equal 0xbadc0ffee0ddf00ddeadbeefn',
      async () => {
        assertEquals(
-           BEToBigInt(Buffer.from([
+           toBigIntBE(Buffer.from([
              0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0, 0x0d, 0xde, 0xad, 0xbe,
              0xef
            ])),
@@ -132,7 +132,7 @@ describe('Try buffer conversion (big endian)', () => {
 
   it('long value should equal long val', async () => {
     assertEquals(
-        BEToBigInt(Buffer.from(
+        toBigIntBE(Buffer.from(
             'badc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeef',
             'hex')),
         BigInt(
@@ -142,39 +142,39 @@ describe('Try buffer conversion (big endian)', () => {
 
 describe('Try bigint conversion (little endian)', () => {
   it('0 should equal 0n', () => {
-    ToLEBuffer(BigInt(`0`), 8).should.deep.equal(Buffer.from([
+    toBufferLE(BigInt(`0`), 8).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0, 0, 0, 0
     ]));
   });
 
   it('1 should equal 1n', async () => {
-    ToLEBuffer(BigInt(`1`), 8).should.deep.equal(Buffer.from([
+    toBufferLE(BigInt(`1`), 8).should.deep.equal(Buffer.from([
       1, 0, 0, 0, 0, 0, 0, 0
     ]));
   });
 
   it('0xdead should equal 0xdeadn (6 byte)', async () => {
-    ToLEBuffer(BigInt(`0xdead`), 6).should.deep.equal(Buffer.from([
+    toBufferLE(BigInt(`0xdead`), 6).should.deep.equal(Buffer.from([
       0xad, 0xde, 0, 0, 0, 0
     ]));
   });
 
   it('0xdeadbeef should equal 0xdeadbeef0000000000n (9 byte)', async () => {
-    ToLEBuffer(BigInt(`0xdeadbeef`), 9).should.deep.equal(Buffer.from([
+    toBufferLE(BigInt(`0xdeadbeef`), 9).should.deep.equal(Buffer.from([
       0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0
     ]));
   });
 
   it('0xbadc0ffee0ddf00d should equal 0xbadc0ffee0ddf00dn (8 byte)',
      async () => {
-       ToLEBuffer(BigInt(`0xbadc0ffee0ddf00d`), 8)
+       toBufferLE(BigInt(`0xbadc0ffee0ddf00d`), 8)
            .should.deep.equal(
                Buffer.from([0x0d, 0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc, 0xba]));
      });
 
   it('0xbadc0ffee0ddf00ddeadbeef should equal 0xbadc0ffee0ddf00ddeadbeefn',
      async () => {
-       ToLEBuffer(BigInt(`0xbadc0ffee0ddf00ddeadbeef`), 12)
+       toBufferLE(BigInt(`0xbadc0ffee0ddf00ddeadbeef`), 12)
            .should.deep.equal(Buffer.from([
              0xef, 0xbe, 0xad, 0xde, 0x0d, 0xf0, 0xdd, 0xe0, 0xfe, 0x0f, 0xdc,
              0xba
@@ -182,7 +182,7 @@ describe('Try bigint conversion (little endian)', () => {
      });
 
   it('long value should equal long val', async () => {
-    ToLEBuffer(BigInt(`0xbadc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeef`), 24)
+    toBufferLE(BigInt(`0xbadc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeef`), 24)
         .should.deep.equal(Buffer.from([
           0xef, 0xbe, 0xad, 0xde, 0x0d, 0xf0, 0xdd, 0xe0,
           0xfe, 0x0f, 0xdc, 0xba, 0xef, 0xbe, 0xad, 0xde,
@@ -194,39 +194,39 @@ describe('Try bigint conversion (little endian)', () => {
 
 describe('Try bigint conversion (big endian)', () => {
   it('0 should equal 0n', () => {
-    ToBEBuffer(BigInt(`0`), 8).should.deep.equal(Buffer.from([
+    toBufferBE(BigInt(`0`), 8).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0, 0, 0, 0
     ]));
   });
 
   it('1 should equal 1n', async () => {
-    ToBEBuffer(BigInt(`1`), 8).should.deep.equal(Buffer.from([
+    toBufferBE(BigInt(`1`), 8).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0, 0, 0, 1
     ]));
   });
 
   it('0xdead should equal 0xdeadn (6 byte)', async () => {
-    ToBEBuffer(BigInt(`0xdead`), 6).should.deep.equal(Buffer.from([
+    toBufferBE(BigInt(`0xdead`), 6).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0xde, 0xad
     ]));
   });
 
   it('0xdeadbeef should equal 0xdeadbeef0000000000n (9 byte)', async () => {
-    ToBEBuffer(BigInt(`0xdeadbeef`), 9).should.deep.equal(Buffer.from([
+    toBufferBE(BigInt(`0xdeadbeef`), 9).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef
     ]));
   });
 
   it('0xbadc0ffee0ddf00d should equal 0xbadc0ffee0ddf00dn (8 byte)',
      async () => {
-       ToBEBuffer(BigInt(`0xbadc0ffee0ddf00d`), 8)
+       toBufferBE(BigInt(`0xbadc0ffee0ddf00d`), 8)
            .should.deep.equal(
                Buffer.from([0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0, 0x0d]));
      });
 
   it('0xbadc0ffee0ddf00ddeadbeef should equal 0xbadc0ffee0ddf00ddeadbeefn',
      async () => {
-       ToBEBuffer(BigInt(`0xbadc0ffee0ddf00ddeadbeef`), 12)
+       toBufferBE(BigInt(`0xbadc0ffee0ddf00ddeadbeef`), 12)
            .should.deep.equal(Buffer.from([
              0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0, 0x0d, 0xde, 0xad, 0xbe,
              0xef
@@ -234,7 +234,7 @@ describe('Try bigint conversion (big endian)', () => {
      });
 
   it('long value should equal long val', async () => {
-    ToBEBuffer(BigInt(`0xbadc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeef`), 24)
+    toBufferBE(BigInt(`0xbadc0ffee0ddf00ddeadbeefbadc0ffee0ddf00ddeadbeef`), 24)
         .should.deep.equal(Buffer.from([
           0xba, 0xdc, 0x0f, 0xfe, 0xe0, 0xdd, 0xf0, 0x0d,
           0xde, 0xad, 0xbe, 0xef, 0xba, 0xdc, 0x0f, 0xfe,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ if (!process.browser) {
  * @param buf The little-endian buffer to convert
  * @returns A BigInt with the little-endian representation of buf.
  */
-export function LEToBigInt(buf: Buffer): BigInt {
+export function toBigIntLE(buf: Buffer): BigInt {
   if (process.browser || converter === undefined) {
     const reversed = Buffer.from(buf);
     reversed.reverse();
@@ -40,7 +40,7 @@ export function LEToBigInt(buf: Buffer): BigInt {
  * @param buf The big-endian buffer to convert.
  * @returns A BigInt with the big-endian representation of buf.
  */
-export function BEToBigInt(buf: Buffer): BigInt {
+export function toBigIntBE(buf: Buffer): BigInt {
   if (process.browser || converter === undefined) {
     const hex = buf.toString('hex');
     if (hex.length === 0) {
@@ -57,7 +57,7 @@ export function BEToBigInt(buf: Buffer): BigInt {
  * @param width The number of bytes that the resulting buffer should be.
  * @returns A little-endian buffer representation of num.
  */
-export function ToLEBuffer(num: BigInt, width: number): Buffer {
+export function toBufferLE(num: BigInt, width: number): Buffer {
   if (process.browser || converter === undefined) {
     const hex = num.toString(16);
     const buffer =
@@ -75,7 +75,7 @@ export function ToLEBuffer(num: BigInt, width: number): Buffer {
  * @param width The number of bytes that the resulting buffer should be.
  * @returns A big-endian buffer representation of num.
  */
-export function ToBEBuffer(num: BigInt, width: number): Buffer {
+export function toBufferBE(num: BigInt, width: number): Buffer {
   if (process.browser || converter === undefined) {
     const hex = num.toString(16);
     return Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');


### PR DESCRIPTION
This PR updates the function names to match standard style,
BE|LE is now a suffix, and function names start with a lower case letter.

Since this change is not backwards compatible with the previous API,
the major version has been incremented to v1.0.0.