### PR TITLE
:rocket: v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {


### PR DESCRIPTION
Due to some errors, v1.0.0 was not deployed properly. This updates the version to v1.0.1 even though it is the same as v1.0.0