### PR TITLE
Types - use primitive type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,27 @@ language: node_js
 node_js:
 - node
 - '10'
+sudo : false
 env:
   global:
   - DISPLAY=:99.0
   - secure: SQDlqZZTkrbRW/wYLPgEwFQpkSrs65MiF0JgO+cwSCAG1m0c7EuBTzvttAXzKK+coZXjd2+QJcAOBi6YUP84OdSf31PojIy4/SLuZxuFQa0sGey+8oSDqgMntpSthO9nom0s6u2vB61IVfcRVIUNv5L3J5i5ZIGlKGgC2MIBzsnhx0L//eyh/bLszR27ajCT7RG+pnqpk010eaDtRabOJTtO0C2kbBQoW2SvJIisDsRj5zqVyl03pZJQQAJeseiNlLokucrgitDWENE+tEJ2w1x1yl+901tgU+BIi4iLQTezcSAxnF149U/Nof7LpCba+1Y+PPh1SRpO4100CT6O46qW0O1keVfTmZL/R3ghBM6H0AtV1s48k/XCpHV9CGwxjBHoCN1kKvSO9B1BJuAdlmgobOEdze+X81nilSBhBmYMI1XPLbXqTo2ImfaFeDzveuPJH6+HMCc+8sDlhgLcrOiteAsY8RsI0ngBkutsWWv7QcRq29e4VX2eBy0j1VJZNf0FPAcKpWF8eIaPw7Z0CuWMs2hM0v0ns58jDcOL+1k4kKyJ10OOmANqNX+NZYRJJ05dd/VMrlh37teARI64PFSG6eIoCniW0GtrUcpX4KhqpaRSUDpsKvncXNdNydumMyMQjeQqyHqahvIE2ONVXXELD2T/EV6TpazDR5KSSo0=
   - secure: ZwKAlaNZ8liLknkAfFN+TztrILi8Q06AknHUj0Zd+9PjzD5n6tpzp5g1nE0MEvF9bqkGkwf6vwWJVKcSXWM9J4a2pfoLe9wsVcjq+AkmWnZG0zV26ie3UPoa8d/PezRtxz+4vErvQcOqnESVPJAqeWCt0fH1WvnEcjaY3BYyyDbWwAPamWr/v9c4ZLKxJqJmgtczMCrRahd6Dz+HGGJ9BehhOXtse+rT5qFI6w2SMXaisDzk2twMu0fK1I66G2IsesIKErPigCeEPahsP2yu831+S18YvxJtao7tXpluMBf+RNhD9eI1evUu6IxpF419ANDJ7BpJ8uGfRVzIz9kQIAmcy/1s7g3otT633XngUfNYDisUeLJ39plclOHw+sVeLL49Xa9k+/U0CzlOThNlCj0hY2uJW3Ot9NjvKDjdR/UkgEBCl6nIDAnRQk9xSJ4ws1f9Yp5CgEXcXvu7077i6O8vG7+k08qHDSkxEEwQjB2PwjhcPfg9ieAwafblM3szYwzblL4UpROp/L/XmmzjR/cOVrS93RIpeLqDr2CCMKGd0GoOFtDse7u43SJMIAZ+O5DNtNpqIQ22V13p4P3L2C1RV3cjE55luEYVR1JZ7AzaxD+hZu2zcU2301MuSgFLTKMEu43HV1tPJ6QtCcSf+kH/LK/TPfTLveW23xkkZM0=
   matrix:
-  - CXX=g++-4.8 TEST_SUITE=test:node
+  - TEST_SUITE=test:node
 addons:
   chrome: stable
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
 before_install:
 - sh -e /etc/init.d/xvfb start
+cache:
+  directories:
+   - $HOME/.npm
 matrix:
   fast_finish: true
   include:
   - os: linux
     node_js: '10'
-    env: CXX=g++-4.8 TEST_SUITE=test:browser
-before_script:
-- npm install -g typescript gts typedoc
+    env: TEST_SUITE=test:browser
 script: npm run $TEST_SUITE
 before_deploy:
 - npm run typedoc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
 interface ConverterInterface {
-  toBigInt(buf: Buffer, bigEndian?: boolean): BigInt;
+  toBigInt(buf: Buffer, bigEndian?: boolean): bigint;
   fromBigInt(num: BigInt, buf: Buffer, bigEndian?: boolean): Buffer;
 }
 
@@ -22,7 +22,7 @@ if (!process.browser) {
  * @param buf The little-endian buffer to convert
  * @returns A BigInt with the little-endian representation of buf.
  */
-export function toBigIntLE(buf: Buffer): BigInt {
+export function toBigIntLE(buf: Buffer): bigint {
   if (process.browser || converter === undefined) {
     const reversed = Buffer.from(buf);
     reversed.reverse();
@@ -40,7 +40,7 @@ export function toBigIntLE(buf: Buffer): BigInt {
  * @param buf The big-endian buffer to convert.
  * @returns A BigInt with the big-endian representation of buf.
  */
-export function toBigIntBE(buf: Buffer): BigInt {
+export function toBigIntBE(buf: Buffer): bigint {
   if (process.browser || converter === undefined) {
     const hex = buf.toString('hex');
     if (hex.length === 0) {
@@ -57,7 +57,7 @@ export function toBigIntBE(buf: Buffer): BigInt {
  * @param width The number of bytes that the resulting buffer should be.
  * @returns A little-endian buffer representation of num.
  */
-export function toBufferLE(num: BigInt, width: number): Buffer {
+export function toBufferLE(num: bigint, width: number): Buffer {
   if (process.browser || converter === undefined) {
     const hex = num.toString(16);
     const buffer =
@@ -75,7 +75,7 @@ export function toBufferLE(num: BigInt, width: number): Buffer {
  * @param width The number of bytes that the resulting buffer should be.
  * @returns A big-endian buffer representation of num.
  */
-export function toBufferBE(num: BigInt, width: number): Buffer {
+export function toBufferBE(num: bigint, width: number): Buffer {
   if (process.browser || converter === undefined) {
     const hex = num.toString(16);
     return Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');


### PR DESCRIPTION
This PR changes the typings to use the primitive type instead of the BigInt type.

This fixes an issue where typescript would complain that the operator '+' is invalid on two BigInts.