### PR TITLE
Fix zero when bytelength mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NPM Package](https://img.shields.io/npm/v/bigint-buffer.svg?style=flat-square)](https://www.npmjs.org/package/bigint-buffer)
 [![Build Status](https://img.shields.io/travis/com/no2chem/bigint-buffer.svg?branch=master&style=flat-square)](https://travis-ci.com/no2chem/bigint-buffer)
 [![Coverage Status](https://img.shields.io/coveralls/no2chem/bigint-buffer.svg?style=flat-square)](https://coveralls.io/r/no2chem/bigint-buffer)
+![node](https://img.shields.io/node/v/bigint-buffer.svg?style=flat-square)
 
 [bigint-buffer](https://www.npmjs.org/package/bigint-buffer) is a utility converts [TC39 Proposed BigInts](https://github.com/tc39/proposal-bigint) to and from buffers. This utility is necessary because BigInts, as proposed, do not support direct conversion between Buffers (or UInt8Arrays), but rather require conversion from buffers to hexadecimal strings then to BigInts, which is suboptimal. This utility includes N-API bindings, so under node, conversion is performed without generating a hexadecimal string. In the browser, normal string conversion is used.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -182,6 +182,14 @@ describe('Try bigint conversion (little endian)', () => {
     ]));
   });
 
+
+  it('1 should equal 1n (32 byte)', async () => {
+    toBufferLE(BigInt(`1`), 32)
+        .should.deep.equal(Buffer.from(
+            '0100000000000000000000000000000000000000000000000000000000000000',
+            'hex'));
+  });
+
   it('0xdead should equal 0xdeadn (6 byte)', async () => {
     toBufferLE(BigInt(`0xdead`), 6).should.deep.equal(Buffer.from([
       0xad, 0xde, 0, 0, 0, 0
@@ -232,6 +240,13 @@ describe('Try bigint conversion (big endian)', () => {
     toBufferBE(BigInt(`1`), 8).should.deep.equal(Buffer.from([
       0, 0, 0, 0, 0, 0, 0, 1
     ]));
+  });
+
+  it('1 should equal 1n (32 byte)', async () => {
+    toBufferBE(BigInt(`1`), 32)
+        .should.deep.equal(Buffer.from(
+            '0000000000000000000000000000000000000000000000000000000000000001',
+            'hex'));
   });
 
   it('0xdead should equal 0xdeadn (6 byte)', async () => {


### PR DESCRIPTION
When converting to a buffer (toBufferBE|LE), the contents of the buffer may not be zeroed, leading to random data if the 64-bit word length of the BigInt mismatches the size of the requested buffer.

This PR fixes this issue by ensuring that the target buffer is properly zeroed.