### PR TITLE
ts -> 3.2rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7153,9 +7153,8 @@
       },
       "dependencies": {
         "typescript": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-          "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+          "version": "github:Microsoft/TypeScript#1df61cb180d45593afdc6bf09301ee7ae656f6e6",
+          "from": "github:Microsoft/TypeScript#v3.2-rc",
           "dev": true
         }
       }
@@ -7167,8 +7166,8 @@
       "dev": true
     },
     "typescript": {
-      "version": "github:calebsander/TypeScript#2280877e21129af345b12962a72e4e1b9196d8fe",
-      "from": "github:calebsander/TypeScript#feature/bigint-lkg",
+      "version": "github:Microsoft/TypeScript#1df61cb180d45593afdc6bf09301ee7ae656f6e6",
+      "from": "github:Microsoft/TypeScript#v3.2-rc",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {
@@ -70,7 +70,7 @@
     "ts-loader": "^4.5.0",
     "ts-node": "^7.0.1",
     "typedoc": "^0.12.0",
-    "typescript": "calebsander/TypeScript#feature/bigint-lkg",
+    "typescript": "Microsoft/TypeScript#v3.2-rc",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "target" : "es2017",
-    "lib" : [ "es2017", "esnext.bigint" ],
-    "sourceMap": true,
-    "experimentalBigInt" : true
+    "target" : "esnext",
+    "lib" : [ "esnext" ],
+    "sourceMap": true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This PR switches the typescript branch used from a development branch to the 3.2-rc branch in the official Microsoft Typescript repository. 

Closes #10