### PR TITLE
Typescript 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7149,12 +7149,13 @@
         "progress": "^2.0.0",
         "shelljs": "^0.8.2",
         "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.0.x"
+        "typescript": "^3.2.1"
       },
       "dependencies": {
         "typescript": {
-          "version": "github:Microsoft/TypeScript#1df61cb180d45593afdc6bf09301ee7ae656f6e6",
-          "from": "github:Microsoft/TypeScript#v3.2-rc",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+          "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
           "dev": true
         }
       }
@@ -7166,8 +7167,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "github:Microsoft/TypeScript#1df61cb180d45593afdc6bf09301ee7ae656f6e6",
-      "from": "github:Microsoft/TypeScript#v3.2-rc",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-buffer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "bigint to buffer conversion with native support",
   "main": "dist/node.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ts-loader": "^4.5.0",
     "ts-node": "^7.0.1",
     "typedoc": "^0.12.0",
-    "typescript": "Microsoft/TypeScript#v3.2-rc",
+    "typescript": "^3.2.1",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },


### PR DESCRIPTION
Now that Typescript 3.2 has been released, this PR switches Typescript from the RC tag to 3.2.1